### PR TITLE
add-on - fix in customFields input

### DIFF
--- a/add-on/README.md
+++ b/add-on/README.md
@@ -66,7 +66,7 @@ Once executed, the splunk env will be available at http://localhost:8000.
       2. Time Occurred - time when alert was triggered
       3. XSOAR Server (if “Send Alert to all the servers” is unchecked)
       4. Type – incident type in XSOAR
-      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a value contains commas, it should be wrapped with apostrophes, quotes, backticks, parenthesis or curly brackets.
+      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a value contains commas or colons, it should be wrapped with apostrophes, quotes, backticks, parenthesis or curly brackets.
       6. Labels – a comma separated values to be put in the labels field
       7. Severity – the alert severity
       8. Details – “details” field of the incident

--- a/add-on/README.md
+++ b/add-on/README.md
@@ -66,7 +66,7 @@ Once executed, the splunk env will be available at http://localhost:8000.
       2. Time Occurred - time when alert was triggered
       3. XSOAR Server (if “Send Alert to all the servers” is unchecked)
       4. Type – incident type in XSOAR
-      5. Custom Fields - A comma separated 'key:value' custom fields pairs
+      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a key or a value contain commas, they should be wrapped with quotes.
       6. Labels – a comma separated values to be put in the labels field
       7. Severity – the alert severity
       8. Details – “details” field of the incident

--- a/add-on/README.md
+++ b/add-on/README.md
@@ -66,7 +66,7 @@ Once executed, the splunk env will be available at http://localhost:8000.
       2. Time Occurred - time when alert was triggered
       3. XSOAR Server (if “Send Alert to all the servers” is unchecked)
       4. Type – incident type in XSOAR
-      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a value contains commas or colons, it should be wrapped with apostrophes, quotes, backticks, parenthesis or curly brackets.
+      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a value contains commas or colons, it should be wrapped with apostrophes, quotation marks, backticks, parenthesis or curly brackets.
       6. Labels – a comma separated values to be put in the labels field
       7. Severity – the alert severity
       8. Details – “details” field of the incident

--- a/add-on/README.md
+++ b/add-on/README.md
@@ -66,7 +66,7 @@ Once executed, the splunk env will be available at http://localhost:8000.
       2. Time Occurred - time when alert was triggered
       3. XSOAR Server (if “Send Alert to all the servers” is unchecked)
       4. Type – incident type in XSOAR
-      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a key or a value contain commas, they should be wrapped with quotes.
+      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a value contains commas, it should be wrapped with quotes.
       6. Labels – a comma separated values to be put in the labels field
       7. Severity – the alert severity
       8. Details – “details” field of the incident

--- a/add-on/README.md
+++ b/add-on/README.md
@@ -66,7 +66,7 @@ Once executed, the splunk env will be available at http://localhost:8000.
       2. Time Occurred - time when alert was triggered
       3. XSOAR Server (if “Send Alert to all the servers” is unchecked)
       4. Type – incident type in XSOAR
-      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a value contains commas, it should be wrapped with quotes.
+      5. Custom Fields - A comma separated 'key:value' custom fields pairs. If a value contains commas, it should be wrapped with apostrophes, quotes, backticks, parenthesis or curly brackets.
       6. Labels – a comma separated values to be put in the labels field
       7. Severity – the alert severity
       8. Details – “details” field of the incident

--- a/add-on/TA-Demisto/app.manifest
+++ b/add-on/TA-Demisto/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-Demisto",
-      "version": "3.0.3"
+      "version": "3.0.4"
     },
     "author": [
       {

--- a/add-on/TA-Demisto/appserver/static/js/build/globalConfig.json
+++ b/add-on/TA-Demisto/appserver/static/js/build/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "TA-Demisto",
         "displayName": "Demisto Add-on for Splunk",
-        "version": "3.0.3",
+        "version": "3.0.4",
         "apiVersion": "3.0.0",
         "restRoot": "TA_Demisto"
     },

--- a/add-on/TA-Demisto/bin/ta_demisto/modalert_create_xsoar_incident_utils.py
+++ b/add-on/TA-Demisto/bin/ta_demisto/modalert_create_xsoar_incident_utils.py
@@ -54,7 +54,8 @@ def split_fields(s):
     temp = ''
     for item in arr:
         temp += item.strip()
-        if ':' in temp and temp.count('"') % 2 == 0 and temp.count('`') % 2 == 0 and temp.count("'") % 2 == 0 and temp.count("(") == temp.count(")") and temp.count("{") == temp.count("}"):
+        if ':' in temp and temp.count('"') % 2 == 0 and temp.count('`') % 2 == 0 and temp.count("'") % 2 == 0 \
+                and temp.count("(") == temp.count(")") and temp.count("{") == temp.count("}"):
             result.append(temp)
             temp = ''
         elif ':' not in temp:

--- a/add-on/TA-Demisto/bin/ta_demisto/modalert_create_xsoar_incident_utils.py
+++ b/add-on/TA-Demisto/bin/ta_demisto/modalert_create_xsoar_incident_utils.py
@@ -37,12 +37,35 @@ def get_incident_labels(helper, event, labels_str, ignore_labels, search_query=N
 
 
 def get_incident_custom_fields(custom_fields_str):
-    str_data = custom_fields_str.strip().split(',')
+    str_data = split_fields(custom_fields_str.strip())
     custom_fields = {}
     for data in str_data:
         param_data = data.split(':')
         custom_fields[param_data[0]] = ':'.join(param_data[1:])
     return custom_fields
+
+
+def split_fields(s):
+    result = []
+    if s is None or len(s) == 0:
+        return result
+
+    arr = s.split(',')
+    temp = ''
+    for item in arr:
+        temp += item.strip()
+        if ':' in temp and temp.count('"') % 2 == 0 and temp.count('`') % 2 == 0 and temp.count("'") % 2 == 0 and temp.count("(") == temp.count(")") and temp.count("{") == temp.count("}"):
+            result.append(temp)
+            temp = ''
+        elif ':' not in temp:
+            if len(result) == 0:
+                result.append(temp)
+            else:
+                result[-1] += (',' + temp)
+            temp = ''
+        else:
+            temp += ','
+    return result
 
 
 def get_incident_occurred_field(occurred):

--- a/add-on/TA-Demisto/bin/ta_demisto/modalert_create_xsoar_incident_utils.py
+++ b/add-on/TA-Demisto/bin/ta_demisto/modalert_create_xsoar_incident_utils.py
@@ -46,6 +46,16 @@ def get_incident_custom_fields(custom_fields_str):
 
 
 def split_fields(s):
+    """ Splits the custom fields string, and takes in count commas which are part of the field value.
+    For example, a possible value for s:
+        "key1:\"val,with,commas\",key2:`val2,with,commas`,key3:(val,3),key4:val4a:val4b"
+    Expected result would be:
+        ["key1:\"val,with,commas\"", "key2:`val2,with,commas`", "key3:(val,3)", "key4:val4a:val4b"]
+
+    :param s: the custom fields string input
+    :return: a key:value list of the custom fields.
+    """
+
     result = []
     if s is None or len(s) == 0:
         return result

--- a/add-on/TA-Demisto/default/app.conf
+++ b/add-on/TA-Demisto/default/app.conf
@@ -8,7 +8,7 @@ install_source_checksum = 4d2246d5dd8b9f38f3e8db59597613d1bc3911cb
 
 [launcher]
 author = Palo Alto Networks
-version = 3.0.3
+version = 3.0.4
 description = This application provides an alert action to create an incident in Cortex XSOAR.
 
 [ui]

--- a/add-on/TA-Demisto/default/data/ui/alerts/create_xsoar_incident.html
+++ b/add-on/TA-Demisto/default/data/ui/alerts/create_xsoar_incident.html
@@ -39,7 +39,7 @@
     <div class="controls">
 	<input type="text" name="action.create_xsoar_incident.param.custom_fields" id="create_xsoar_incident_custom_fields"/>
                 <span class="help-block">
-                    A comma separated 'key:value' custom fields pairs, e.g. killchain:1.1.1.1,User:john
+                    A comma separated 'key:value' custom fields pairs, e.g. killchain:1.1.1.1,User:john,"key,with,commas":"val,with,commas"
                 </span>
     </div>
 </div>

--- a/add-on/TA-Demisto/default/data/ui/alerts/create_xsoar_incident.html
+++ b/add-on/TA-Demisto/default/data/ui/alerts/create_xsoar_incident.html
@@ -39,7 +39,7 @@
     <div class="controls">
 	<input type="text" name="action.create_xsoar_incident.param.custom_fields" id="create_xsoar_incident_custom_fields"/>
                 <span class="help-block">
-                    A comma separated 'key:value' custom fields pairs, e.g. killchain:1.1.1.1,User:john,"key,with,commas":"val,with,commas"
+                    A comma separated 'key:value' custom fields pairs, e.g. killchain:1.1.1.1,User:john,key:"value,with,commas"
                 </span>
     </div>
 </div>


### PR DESCRIPTION
contribution: Added an option to input custom fields with values that contain commas/colons. The values in this case should be wrapped with apostrophes, quotes, backticks, parenthesis or curly brackets, for example:
```
test1:"bla,test",test2:`bla,test2`,test3:(bla,test3),test4:'bla,test4',test5:test5val
```
results:
![image](https://user-images.githubusercontent.com/38749041/111622893-5f8f6300-87f2-11eb-8838-2484d18e9eec.png)
